### PR TITLE
Ignore "!" methods when importing Ruby Math methods

### DIFF
--- a/lib/dentaku/ast/functions/ruby_math.rb
+++ b/lib/dentaku/ast/functions/ruby_math.rb
@@ -2,6 +2,7 @@
 require_relative "../function"
 
 Math.methods(false).each do |method|
+  next if method.to_s.include?("!")
   Dentaku::AST::Function.register(method, :numeric, ->(*args) {
     Math.send(method, *args)
   })


### PR DESCRIPTION
When trying to use Dentaku I ran into a problem.

Because of the nature of how Dentaku registers functions to be used (it tries to turn the name into a constant) there can be issues if another gem defines a method with a "!" in it.

This pull request changes how Math methods are included to ignore the bang methods.

Thanks!